### PR TITLE
Update refreshing_access_tokens.md

### DIFF
--- a/docs/sso/refreshing_access_tokens.md
+++ b/docs/sso/refreshing_access_tokens.md
@@ -10,18 +10,19 @@ To get a new access token you must make a POST request to `https://login.eveonli
 
 - `scope=<subset of scopes from the original OAuth 2.0 flow>` **[OPTIONAL]**: Replace everything after `=` with your own value. A subset of the original scopes assigned to the authorization and refresh token. If omitted, all original scopes will be assigned to the new access token.
 
->If your application is web based (and you followed the [web based sso flow](web_based_sso_flow.md)) you also need to include an Authentication header ([basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) with the client ID as the username and secret key as the password).
+- `client_id=<your application's client ID>`: Replace everything after `=` with the client ID assigned to your application.
 
-The request should look like this (**don't include the `Authorization` header if your application is a mobile or desktop application**):
+- `client_secret=<your application's client secret>` **[OPTIONAL]**: Replace everything after `=` with the client secret assigned to your application. This is only required if your application is web based (you followed the [web based sso flow](web_based_sso_flow.md)).
+
+The request should look like this:
 
 ```http
 POST https://login.eveonline.com/v2/oauth/token HTTP/1.1
 
-Authorization: Basic bG9...ZXQ=
 Content-Type: application/x-www-form-urlencoded
 Host: login.eveonline.com
 
-grant_type=refresh_token&refresh_token=gEy...fM0
+grant_type=refresh_token&refresh_token=gEy...fM0&client_id=9f1...8d2
 ```
 
 The response should contain details about the new access token for that user. Example:

--- a/docs/sso/refreshing_access_tokens.md
+++ b/docs/sso/refreshing_access_tokens.md
@@ -1,8 +1,13 @@
-## Refreshing tokens
+# Refreshing tokens
 
 If any valid scope was requested in the initial redirect to the SSO using the authorization code flow, a refresh token will be returned by the token endpoint, along with the access token. While the access token will expire after the listed interval, the refresh token can be stored and used indefinitely. Users can revoke access for individual apps on the [support site](https://community.eveonline.com/support/third-party-applications/).
 
-To get a new access token you must make a POST request to `https://login.eveonline.com/v2/oauth/token` with the following parameters:
+The method for refreshing access tokens is dependent on whether your application is a [web based](web_based_sso_flow) or [native](native_sso_flow) (e.g mobile/desktop) application. Jump to the section below that applies to your application.
+
+## Web Based Applications
+As a web based application you will need to make a URL-encoded POST request to `https://login.eveonline.com/v2/oauth/token` using [basic authentication]((https://en.wikipedia.org/wiki/Basic_access_authentication)) where your application's client ID is the user and your secret key is the password.
+
+You will need to pass the following parameters:
 
 - `grant_type=refresh_token`
 
@@ -10,11 +15,40 @@ To get a new access token you must make a POST request to `https://login.eveonli
 
 - `scope=<subset of scopes from the original OAuth 2.0 flow>` **[OPTIONAL]**: Replace everything after `=` with your own value. A subset of the original scopes assigned to the authorization and refresh token. If omitted, all original scopes will be assigned to the new access token.
 
+You will need to pass the following HTTP headers:
+
+- `Content-Type: application/x-www-form-urlencoded`
+- `Host: login.eveonline.com`
+- `Authorization: Basic <base64 encoded string containing your client ID and secret key joined by a single colon (:)>`: Replace everything after `Basic ` with the content described between `<>`.
+
+The request should look like something like this:
+
+```http
+POST https://login.eveonline.com/v2/oauth/token HTTP/1.1
+
+Content-Type: application/x-www-form-urlencoded
+Host: login.eveonline.com
+Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l  
+
+grant_type=refresh_token&refresh_token=gEy...fM0
+```
+## Native Applications
+As a native application you will need to make a URL-encoded POST request to `https://login.eveonline.com/v2/oauth/token` containing the following parameters:
+
+- `grant_type=refresh_token`
+
+- `refresh_token=<refresh token from previous request to token endpoint>`: Replace everything after `=` with your own value.
+
 - `client_id=<your application's client ID>`: Replace everything after `=` with the client ID assigned to your application.
 
-- `client_secret=<your application's client secret>` **[OPTIONAL]**: Replace everything after `=` with the client secret assigned to your application. This is only required if your application is web based (you followed the [web based sso flow](web_based_sso_flow.md)).
+- `scope=<subset of scopes from the original OAuth 2.0 flow>` **[OPTIONAL]**: Replace everything after `=` with your own value. A subset of the original scopes assigned to the authorization and refresh token. If omitted, all original scopes will be assigned to the new access token.
 
-The request should look like this:
+You will need to pass the following HTTP headers:
+
+- `Content-Type: application/x-www-form-urlencoded`
+- `Host: login.eveonline.com`
+
+The request should look like something like this:
 
 ```http
 POST https://login.eveonline.com/v2/oauth/token HTTP/1.1
@@ -25,7 +59,8 @@ Host: login.eveonline.com
 grant_type=refresh_token&refresh_token=gEy...fM0&client_id=9f1...8d2
 ```
 
-The response should contain details about the new access token for that user. Example:
+## SSO Response
+The response from the SSO contains details about the new access token for that user and will look similar to this:
 
 ```json
 {


### PR DESCRIPTION
Lately, there have been a lot of complaints on Tweetfleet Slack from people following the docs, trying to use the PKCE flow, not being able to use their refresh tokens to generate new access tokens. The `/v2/oauth/token` endpoint was producing the following error:
```json
{
  "error": "invalid_client",
  "error_description": "Missing or invalid client credentials."
}
```
To avoid this error, it is necessary to include the application's `client_id` in the request body along with the refresh token.

This PR updates the docs to indicate this, and to keep them simpler, also suggests including the client secret (when necessary) in the request body instead of using the `Authorization` header.

Please note that currently, the SSO does not require the client secret to be provided when using a refresh token, no matter which type of flow was used to generate it. I am unsure if this is intended behaviour, a bug, or a transitionary measure.