### PR TITLE
Fixed broken links to python example files

### DIFF
--- a/docs/sso/native_sso_flow.md
+++ b/docs/sso/native_sso_flow.md
@@ -25,7 +25,7 @@ Here is the OAuth 2.0 flow your native application should be implementing:
 
     * `code_challenge=<URL safe Base64(SHA256(URL safe Base64(random 32 byte string)))>` - In the PCKE protocol, a code challenge is used instead of basic authentication to allow your application to ship without its secret key. The reason for this being to protect malicious actors from being able to decompile your programs and retrieve the secret key. A more detailed explanation of the kind of attacks this protects against can be found in [RFC7636](https://tools.ietf.org/html/rfc7636#section-1)
 
-        To correctly create a code challenge your application will need to make a one time use only 32 byte random string. You will then URL safe Base64 encode this random string, then hash that and finally URL safe Base64 encode the hashed value. The resulting Base64 encoded string is the code challenge. Make sure you keep the original Base64 encoded random value for later as you will need to use that in step 5. If you'd like to see an example of creating a code challenge in Python you can find that [here](../examples/python/sso/esi_oauth_native.py). *Feel free to contribute examples in other languages to this repository to help others.*
+        To correctly create a code challenge your application will need to make a one time use only 32 byte random string. You will then URL safe Base64 encode this random string, then hash that and finally URL safe Base64 encode the hashed value. The resulting Base64 encoded string is the code challenge. Make sure you keep the original Base64 encoded random value for later as you will need to use that in step 5. If you'd like to see an example of creating a code challenge in Python you can find that [here](../../examples/python/sso/esi_oauth_native.py). *Feel free to contribute examples in other languages to this repository to help others.*
 
     * `code_challenge_method=S256` - This is telling the EVE SSO that the code challenge was hashed using the [SHA-256 hashing algorithm](https://en.wikipedia.org/wiki/SHA-2) and is the only method currently accepted at this time.
 
@@ -71,7 +71,7 @@ The following diagram is a visual representation of the steps above. Any number 
 
 ![Native OAuth 2.0 Flow Diagram](img/native_oauth_flow.svg)
 
-If any of this is confusing, there is a [code example](../examples/python/sso/esi_oauth_native.py) available in Python that you can run locally to see this flow in action.
+If any of this is confusing, there is a [code example](../../examples/python/sso/esi_oauth_native.py) available in Python that you can run locally to see this flow in action.
 
 ## Further reading
 You can continue by reading about [how to send an authorized request to ESI](sending_esi_auth_request.md) or you can read about [how to get a new access token using your refresh token](refreshing_access_tokens.md).


### PR DESCRIPTION
Python example file links were broken, I fixed them. Guessing the structure changed at some point.