### PR TITLE
Replace relative links to code examples with absolute links

### DIFF
--- a/docs/sso/native_sso_flow.md
+++ b/docs/sso/native_sso_flow.md
@@ -25,7 +25,7 @@ Here is the OAuth 2.0 flow your native application should be implementing:
 
     * `code_challenge=<URL safe Base64(SHA256(URL safe Base64(random 32 byte string)))>` - In the PCKE protocol, a code challenge is used instead of basic authentication to allow your application to ship without its secret key. The reason for this being to protect malicious actors from being able to decompile your programs and retrieve the secret key. A more detailed explanation of the kind of attacks this protects against can be found in [RFC7636](https://tools.ietf.org/html/rfc7636#section-1)
 
-        To correctly create a code challenge your application will need to make a one time use only 32 byte random string. You will then URL safe Base64 encode this random string, then hash that and finally URL safe Base64 encode the hashed value. The resulting Base64 encoded string is the code challenge. Make sure you keep the original Base64 encoded random value for later as you will need to use that in step 5. If you'd like to see an example of creating a code challenge in Python you can find that [here](../../examples/python/sso/esi_oauth_native.py). *Feel free to contribute examples in other languages to this repository to help others.*
+        To correctly create a code challenge your application will need to make a one time use only 32 byte random string. You will then URL safe Base64 encode this random string, then hash that and finally URL safe Base64 encode the hashed value. The resulting Base64 encoded string is the code challenge. Make sure you keep the original Base64 encoded random value for later as you will need to use that in step 5. If you'd like to see an example of creating a code challenge in Python you can find that [here](https://github.com/esi/esi-docs/blob/master/examples/python/sso/esi_oauth_native.py). *Feel free to contribute examples in other languages to this repository to help others.*
 
     * `code_challenge_method=S256` - This is telling the EVE SSO that the code challenge was hashed using the [SHA-256 hashing algorithm](https://en.wikipedia.org/wiki/SHA-2) and is the only method currently accepted at this time.
 
@@ -37,7 +37,7 @@ If you wanted access to a character's blueprints and your callback URL was `http
 
     Your application needs to lift the value of the `code` query parameter from the URL so that it can be used in the next step. This authorization code is a one time use only token that has a lifetime of 5 minutes. If you do not respond within 5 minutes you will have to start over at step 1 again.
 
-5. Now that your application has the authorization code, it needs to send a POST request to `https://login.eveonline.com/v2/oauth/token` with a payload containing the returned authorization code, the client ID of your application, and the original URL safe Base 64 encoded 32 byte string that was randomly created for the code challenge in step 3. *Note: you can look at a Python example of this returning a code verifier [here](../examples/python/sso/esi_oauth_native.py)*.
+5. Now that your application has the authorization code, it needs to send a POST request to `https://login.eveonline.com/v2/oauth/token` with a payload containing the returned authorization code, the client ID of your application, and the original URL safe Base 64 encoded 32 byte string that was randomly created for the code challenge in step 3. *Note: you can look at a Python example of this returning a code verifier [here](https://github.com/esi/esi-docs/blob/master/examples/python/sso/esi_oauth_native.py)*.
 
 Here is a little more detail on how to craft this request:
 
@@ -71,7 +71,7 @@ The following diagram is a visual representation of the steps above. Any number 
 
 ![Native OAuth 2.0 Flow Diagram](img/native_oauth_flow.svg)
 
-If any of this is confusing, there is a [code example](../../examples/python/sso/esi_oauth_native.py) available in Python that you can run locally to see this flow in action.
+If any of this is confusing, there is a [code example](https://github.com/esi/esi-docs/blob/master/examples/python/sso/esi_oauth_native.py) available in Python that you can run locally to see this flow in action.
 
 ## Further reading
 You can continue by reading about [how to send an authorized request to ESI](sending_esi_auth_request.md) or you can read about [how to get a new access token using your refresh token](refreshing_access_tokens.md).

--- a/docs/sso/revoking_refresh_tokens.md
+++ b/docs/sso/revoking_refresh_tokens.md
@@ -48,4 +48,4 @@ If you know your refresh token has been compromised, it is important to revoke i
 
 3. If the revocation was successful you will get an HTTP response code of 200 back from the EVE SSO.
 
-If you'd like to look at an example of revoking a refresh token written in Python you can find one [here](../examples/python/sso/revoke_refresh_token.py).
+If you'd like to look at an example of revoking a refresh token written in Python you can find one [here](https://github.com/esi/esi-docs/blob/master/examples/python/sso/revoke_refresh_token.py).

--- a/docs/sso/validating_eve_jwt.md
+++ b/docs/sso/validating_eve_jwt.md
@@ -36,4 +36,4 @@ You will need to ensure three things when validating a JWT token from the EVE SS
     The `exp` claim contains the expiry date of the token as a UNIX timestamp. You can use that to know when to refresh the token and to make sure that the token is valid.
 
 
-You can look [here](../../examples/python/sso/validate_jwt.py) for a code example in Python showing you how to validate a JWT token.
+You can look [here](https://github.com/esi/esi-docs/blob/master/examples/python/sso/validate_jwt.py) for a code example in Python showing you how to validate a JWT token.

--- a/docs/sso/web_based_sso_flow.md
+++ b/docs/sso/web_based_sso_flow.md
@@ -66,7 +66,7 @@ The following diagram is a visual representation of the steps above. Any number 
 
 ![Web based OAuth 2.0 Flow Diagram](img/web_oauth_flow.svg)
 
-If any of this is confusing, there is a [code example](../examples/python/sso/esi_oauth_web.py) available in Python that you can run locally to see this flow in action.
+If any of this is confusing, there is a [code example](https://github.com/esi/esi-docs/blob/master/examples/python/sso/esi_oauth_web.py) available in Python that you can run locally to see this flow in action.
 
 ## Further reading
 You can continue by reading about [how to send an authorized request to ESI](sending_esi_auth_request.md) or you can read about [how to get a new access token using your refresh token](refreshing_access_tokens.md).


### PR DESCRIPTION
When the links to the code examples are clicked from the https://docs.esi.evetech.net/ site, they will lead to the raw `.py` files, which will then be downloaded by the browser instead of the code being displayed, as it would be if the docs were accessed from the code browser.

I consider this behavior undesirable, and have fixed it by replacing the relative links with absolute ones. This ensures that the code examples are always opened in the GH interface, and also fixes a couple of broken links that weren't covered in #7.