### PR TITLE
Remove list of third-party libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ If you're adding a new document, please be sure to include a link here somewhere
 
 - [ESI Introduction](docs/esi_introduction.md)
 - [Frequently Asked Questions](docs/FAQ.md)
-- [Third Party Libraries](docs/third_party_libraries.md)
 - [Transitioning from XML](docs/XML_to_ESI.md)
 - [Transitioning from CREST](docs/CREST_to_ESI.md)
 - [What defines a breaking change](docs/breaking_changes.md)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,7 +24,7 @@ They embed the version in the path, resulting in more stable clients. [Please re
 
 ### Is there an ESI client library in &lt;language_x&gt;?
 
-Probably. Check the [awesome-eve](https://github.com/devfleet/awesome-eve) repository. If you can't find something there for your language, you can try the [Swagger open source integrations page](https://swagger.io/open-source-integrations/).
+Probably. Check the [awesome-eve](https://github.com/devfleet/awesome-eve#developer-tools--libraries) repository. If you can't find something there for your language, you can try the [Swagger open source integrations page](https://swagger.io/open-source-integrations/).
 
 ### What happened to CREST and XML API?
 

--- a/docs/third_party_libraries.md
+++ b/docs/third_party_libraries.md
@@ -1,38 +1,5 @@
-# Third Party Libraries
+# Third-party Libraries
 
-A number of third party libraries are available to speed your app development rather than reinventing the wheel.
+A number of third-party libraries are available to speed up your app development.
 
-## Libraries
-
-| Language   | Library                                                                | OAuth2  | Style   | ETags | h2             |
-|------------|------------------------------------------------------------------------|---------|---------|-------|----------------|
-| go         | [GoESI](https://github.com/antihax/goesi)                              | Yes     | codegen | Yes   | Yes            |
-| go         | [go-eveonline](https://github.com/pequalsnp/go-eveonline)              | Library | static  | No    | Yes            |
-| PHP        | [eseye](https://github.com/eveseat/eseye)                              | Library | dynamic | Yes   | Depends on PHP |
-| PowerShell | [POSH](https://github.com/markus-lassfolk/EVE-Online-ESI-Posh)         | Yes     | static  | No    | No             |
-| Python     | [EsiPy](https://github.com/Kyria/EsiPy)                                | Yes     | dynamic | Yes   | Yes            |
-| .NET       | [ESI.NET](https://github.com/seraphx2/ESI.NET)                         | Yes     | static  | No    | No             |
-| Ruby       | [EVEOnline ESI API](https://github.com/biow0lf/eve_online)             | Library | static  | No    | No             |
-| Java       | [eve-esi](https://github.com/burberius/eve-esi)                        | Yes     | codegen | Yes   | No             |
-| Java       | [eve-esi-client](https://github.com/OrbitalEnterprises/eve-esi-client) | Yes     | codegen | Yes   | No             |
-
-## Features
-
-| Feature | Description                                                                        |
-|---------|------------------------------------------------------------------------------------|
-| OAuth2  | Supports OAuth2 flows. May be included via a library.                              |
-| Style   | See Style table below.                                                             |
-| ETags   | Supports ETag based cache to reduce bandwidth consumption.                         |
-| h2      | Supports http2 request multiplexing to send concurrent requests over a connection. |
-
-## Styles
-
-| Style   | Description                                |
-|---------|--------------------------------------------|
-| codegen | Automatically rebuilt as endpoints change. |
-| dynamic | Builds model in memory each run.           |
-| static  | Built by hand.                             |
-
-## Disclaimer
-
-These libraries are not maintained by CCP Games.
+A list of such libraries can be found in the [devfleet/awesome-eve](https://github.com/devfleet/awesome-eve#developer-tools--libraries) repository.

--- a/docs/third_party_libraries.md
+++ b/docs/third_party_libraries.md
@@ -1,5 +1,0 @@
-# Third-party Libraries
-
-A number of third-party libraries are available to speed up your app development.
-
-A list of such libraries can be found in the [devfleet/awesome-eve](https://github.com/devfleet/awesome-eve#developer-tools--libraries) repository.


### PR DESCRIPTION
Such a list already exists over at [devfleet/awesome-eve](https://github.com/devfleet/awesome-eve#developer-tools--libraries), and having a competing one here just creates unnecessary maintenance burden.

Resolves https://github.com/esi/esi-docs/issues/14, waiting on https://github.com/devfleet/awesome-eve/pull/121.