### PR TITLE
Add info about monolith rate limits

### DIFF
--- a/docs/esi_introduction.md
+++ b/docs/esi_introduction.md
@@ -55,5 +55,7 @@ There are no rate limits in place, ESI relies on caching more than rate limiting
 
 ESI returns standard caching headers if the data is cached. Applications should notice and make use of these headers (expires and last-modified) on routes where they are provided.
 
+Some endpoints, specifically for sending mail and reading contracts, have internal rate limits enforced by the EVE monolith. If these rate limits are exceeded, ESI will return HTTP status code 520. 
+
 ESI is a shared resource and projects should be optimized to have minimum consumption of unnecessary resources. In the case of long running
 services, consistent amounts of slow traffic are preferred to spiky, high throughput traffic.


### PR DESCRIPTION
Monolith rate limiting should be mentioned in the rate limiting section of the docs. 

Should also be accompanied by adding more specific mention of rate limit to the Swagger docs, will make a separate issue in esi-issues for that