### PR TITLE
ADD section about enums to breaking_changes.md

### DIFF
--- a/docs/breaking_changes.md
+++ b/docs/breaking_changes.md
@@ -8,31 +8,31 @@ For the purposes of this document, parameter means input, whereas attribute refe
 
 Change Description                        | Version Bump Required
 ------------------------------------------|----------------------
-Update description/summary/example        | no
-Adding optional attribute or parameter    | no
-Adding required parameter                 | yes
-Adding required attribute                 | no
-Removing optional attribute               | no
-Removing required attribute               | yes
-Removing parameter                        | no
-Optional attribute becomes required       | no
-Required attribute becomes optional       | yes
-Optional parameter becomes required       | yes
-Required parameter becomes optional       | no
-Changing attribute or parameter name      | yes
-Changing values in an Enum                | yes
-Adding values to an attribute Enum        | no
-Removing values from an attribute Enum    | no
-Adding values to an parameter Enum        | no
-Removing values from an parameter Enum    | yes
-Adding pagination with `x-pages`          | no
-Reducing attribute maxItems               | no
-Increasing attribute maxItems             | yes
-Reducing parameter maxItems               | yes
-Increasing parameter maxItems             | no
-Changing cache expiry                     | no
-Changing security requirements            | yes
-Changing `x-required-roles` (as dictated) | no
+Update description/summary/example              | no
+Adding optional attribute or parameter          | no
+Adding required parameter                       | yes
+Adding required attribute                       | no
+Removing optional attribute                     | no
+Removing required attribute                     | yes
+Removing parameter                              | no
+Optional attribute becomes required             | no
+Required attribute becomes optional             | yes
+Optional parameter becomes required             | yes
+Required parameter becomes optional             | no
+Changing attribute or parameter name            | yes
+Changing values in an Enum                      | yes
+[Adding values to an attribute Enum](#Enum)     | no
+Removing values from an attribute Enum          | no
+Adding values to an parameter Enum              | no
+Removing values from an parameter Enum          | yes
+Adding pagination with `x-pages`                | no
+Reducing attribute maxItems                     | no
+Increasing attribute maxItems                   | yes
+Reducing parameter maxItems                     | yes
+Increasing parameter maxItems                   | no
+Changing cache expiry                           | no
+Changing security requirements                  | yes
+Changing `x-required-roles` (as dictated)       | no
 
 
 ## Type changes
@@ -55,3 +55,8 @@ string/date-time | string/date      | yes                | no
 For any parameter or attribute defined with only a type (format is optional according to swagger spec), it is not a breaking change to clarify the definition to add any format within the type.
 
 Any transition not specifically listed is a breaking change for both parameters and attributes.
+
+
+## Enum
+
+As extending enums with new values does not constitute a breaking change treat all `string` attributes accompanied with enumerations simply as `string`. 


### PR DESCRIPTION
- Adds additional information about extending enums not being
  a breaking change.