### PR TITLE
ADD section with common scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ If you're adding a new document, please be sure to include a link here somewhere
 - [Asset location_id](docs/asset_location_id.md)
 - [Notifications](docs/notifications.md)
 
+### Common Scenarios
+- [Resolve Structure IDs](docs/scenarios/resolve_structure_ids.md)
+- [Retrieve Structure Markets](docs/scenarios/structure_markets.md)
+
 ### SSO
 
 - [Introduction](docs/sso/README.md)

--- a/docs/scenarios/resolve_structre_ids.md
+++ b/docs/scenarios/resolve_structre_ids.md
@@ -6,17 +6,17 @@ The endpoint returns the name of the structure, as well as some additional infor
 
 ## Discovering Upwell Structures
 
-There is currently no unified way discver accessible Upwell structures through ESI. The following methods can be used to discover Upwell structure IDs.
+There is currently no unified way to discover accessible Upwell structures through ESI. The following methods can be used to discover Upwell structure IDs.
 
 ### Public Structures
 
-The public `/universe/structures/` endpoint will return a flat list of IDs containing all fully public structures. *Fully public* in this context means a completely open Access Control List. If the ACL prevents anyone from docking the structure won't show up in this list.
+The public `/universe/structures/` endpoint will return a flat list of IDs containing all fully public structures. *Fully public* in this context means a completely open Access Control List. If the ACL prevents even one character from docking the structure won't show up in this list.
 
 This method has the advantage of not requiring any authentication but is limited in that it only resolves completely public structures. Additionally, most endpoints that consume structure IDs require authentication anyways, so you likely won't be possible to avoid supplying a token anyways.
 
 ### Corporation Structures
 
-The authenticated `/corporations/{corporation_id}/structures/` endpoit returns all structures owned by a particular corporation. It requires a token that grants the `esi-corporations.read_structures.v1` scope on a character with Director roles in the corporation.
+The authenticated `/corporations/{corporation_id}/structures/` endpoint returns all structures owned by a particular corporation. It requires a token that grants the `esi-corporations.read_structures.v1` scope on a character with the Director role in the corporation.
 
 This endpoint provides a lot of information about the structure, including what services are installed and active, when the fuel expires, what state it currently is in etc. Be aware that it currently *does not* provide the name of the structure.
 
@@ -29,5 +29,5 @@ Some other endpoints may also include structure ids in their results. Structure 
 - Character Location
 - Clone locations
 - Fleet member station_id may be structure ids
-- industry jobs may be located in structure ids
+- Industry jobs may be located in structure ids
 - Character and Corporation market orders may have location_ids that are structures.

--- a/docs/scenarios/resolve_structre_ids.md
+++ b/docs/scenarios/resolve_structre_ids.md
@@ -1,0 +1,33 @@
+## Resolving Upwell Structure IDs
+
+A common scenario is to resolve a structure ID into a name. Use the authenticated `/universe/structures/{structure_id}/` endpoint for that. It requires a token that grants the `esi-universe.read_structures.v1` scope on a character that has docking access to the structure. 
+
+The endpoint returns the name of the structure, as well as some additional information such as its system id, type id and the owner corporation id.
+
+## Discovering Upwell Structures
+
+There is currently no unified way discver accessible Upwell structures through ESI. The following methods can be used to discover Upwell structure IDs.
+
+### Public Structures
+
+The public `/universe/structures/` endpoint will return a flat list of IDs containing all fully public structures. *Fully public* in this context means a completely open Access Control List. If the ACL prevents anyone from docking the structure won't show up in this list.
+
+This method has the advantage of not requiring any authentication but is limited in that it only resolves completely public structures. Additionally, most endpoints that consume structure IDs require authentication anyways, so you likely won't be possible to avoid supplying a token anyways.
+
+### Corporation Structures
+
+The authenticated `/corporations/{corporation_id}/structures/` endpoit returns all structures owned by a particular corporation. It requires a token that grants the `esi-corporations.read_structures.v1` scope on a character with Director roles in the corporation.
+
+This endpoint provides a lot of information about the structure, including what services are installed and active, when the fuel expires, what state it currently is in etc. Be aware that it currently *does not* provide the name of the structure.
+
+### Other endpoints
+
+Some other endpoints may also include structure ids in their results. Structure IDs can usually be distinguished because they are in the int64 range while currently most other IDs are in the int32 range. The following endpoints will often return structure IDs:
+
+- All contract endpoints may have location_ids that are structures
+- Character and Corporation asset location_ids
+- Character Location
+- Clone locations
+- Fleet member station_id may be structure ids
+- industry jobs may be located in structure ids
+- Character and Corporation market orders may have location_ids that are structures.

--- a/docs/scenarios/structure_markets.md
+++ b/docs/scenarios/structure_markets.md
@@ -1,6 +1,6 @@
 ## Resolving Structure Markets
 
-Structure market orders, with the exception or ranged orders, are not included in the results of `/markets/{region_id}/orders/`. They have to be queried individually and then merged.
+Structure market orders, with the exception of ranged orders, are not included in the results of `/markets/{region_id}/orders/`. They have to be queried individually and then merged.
 
 ### Query individual structure markets
 

--- a/docs/scenarios/structure_markets.md
+++ b/docs/scenarios/structure_markets.md
@@ -1,0 +1,13 @@
+## Resolving Structure Markets
+
+Structure market orders, with the exception or ranged orders, are not included in the results of `/markets/{region_id}/orders/`. They have to be queried individually and then merged.
+
+### Query individual structure markets
+
+The authenticated endpoint `/markets/structures/{structure_id}/` can be used to retrieve market orders for a single Upwell structure. It requires an access token that grants the scope `esi-markets.structure_markets.v1` for a character with docking access to the structure.
+
+See [Resolve Structure IDs](/docs/scenarios/resolve_structre_ids.md) for information on how to get the IDs of Upwell structures.
+
+The endpoint will return all orders in the structure, it does not support filtering by order type or type id.
+
+Pay attention to the `X-Pages` header in the response, multiple requests with the `page` query parameter may be necessary to retrieve all orders.


### PR DESCRIPTION
There are various scenarios that often come up in the #esi channel on slack.

This change adds a section to the docs to document some solutions to these common scenarios to prevent people from having to keep writing the same responses and hopefully act as a bit of a knowledge base for common problems.

Currently it includes documentation for two scenarios, resolving upwell structure IDs and resolving structure market orders.