### PR TITLE
Fix imprecision on token revocation page

### DIFF
--- a/docs/sso/revoking_refresh_tokens.md
+++ b/docs/sso/revoking_refresh_tokens.md
@@ -44,6 +44,6 @@ If you know your refresh token has been compromised, it is important to revoke i
 
     Replace all text wrapped with `<>` with a value provided by you.
 
-3. If the revocation was successful you will get an HTTP response code of 200 back from the EVE SSO.
+3. The server responds with a 200 OK response code. If you submitted a valid token, the server has now invalidated it. Note that the server also returns a 200 OK if the token was invalid, because in both cases the end result is the same - you are not able to use the token to successfully request a new access token.
 
 If you'd like to look at an example of revoking a refresh token written in Python you can find one [here](https://github.com/esi/esi-docs/blob/master/examples/python/sso/revoke_refresh_token.py).


### PR DESCRIPTION
This should clarify that the token revocation endpoint returns a 200 OK even when the posted token is invalid.

Fixes #36
