### PR TITLE
Revocation endpoint form bodies

### DIFF
--- a/docs/sso/revoking_refresh_tokens.md
+++ b/docs/sso/revoking_refresh_tokens.md
@@ -33,16 +33,19 @@ If you know your refresh token has been compromised, it is important to revoke i
 
     From here you want to get the value of the key `revocation_endpoint`, which at this time of writing is `https://login.eveonline.com/v2/oauth/revoke`.
 
-2. Make a POST request to the revocation endpoint retrieved from step 1 using [basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication), where your application's client ID is the user and your application's secret key is the password, with the body:
+2. Make a POST request to the revocation endpoint retrieved from step 1 using [basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication), where your application's client ID is the user and your application's secret key is the password, with the form encoded body:
 
-    ```JSON
-    {
-        "token": <your refresh token to revoke>,
-        "token_type_hint": "refresh_token"
-    }
+    ```
+    token_type_hint=refresh_token&token=<your refresh token to revoke>
     ```
 
     Replace all text wrapped with `<>` with a value provided by you.
+
+    Make sure to set the correct Content-Type header:
+
+    ```
+    Content-Type: application/x-www-form-urlencoded
+    ```
 
 3. If the revocation was successful you will get an HTTP response code of 200 back from the EVE SSO.
 

--- a/examples/python/sso/revoke_refresh_token.py
+++ b/examples/python/sso/revoke_refresh_token.py
@@ -46,19 +46,19 @@ def revoke_refresh_token(refresh_token, client_id, secret_key):
               "{}".format(sso_meta))
         sys.exit(1)
 
-    body = {
+    form_values = {
         "token": refresh_token,
         "token_type_hint": "refresh_token"
     }
 
     res = requests.post(
         revocation_endpoint,
-        json=body,
+        data=form_values,
         auth=(client_id, secret_key)
     )
 
     print("Made a request to {} with body: {} using basic "
-          "authentication".format(revocation_endpoint, body))
+          "authentication".format(revocation_endpoint, res.request.body))
 
     if res.status_code != 200:
         print("Something went wrong with the request to revoke your token. "


### PR DESCRIPTION
I updated the documentation and example implementation of the revocation endpoint to use form encoded values instead of JSON for the revocation request.

Fix #17 