### PR TITLE
Clarify Auth header requirements

### DIFF
--- a/docs/sso/web_based_sso_flow.md
+++ b/docs/sso/web_based_sso_flow.md
@@ -37,10 +37,10 @@ Here is the OAuth 2.0 flow your web based application should be implementing:
 
         grant_type=authorization_code&code=<authorization code from callback URL>
 
-* Create a URL safe Base64 encoded string where the contents before encoding are your application's client ID, followed by a `:`, followed by your application's secret key (e.g. `URL safe Base64(<client_id>:<secret_key>)`).
+* Create a Base64 encoded string, including padding, where the contents before encoding are your application's client ID, followed by a `:`, followed by your application's secret key (e.g. `Base64(<client_id>:<secret_key>)`). For example, given the input `CLIENT_ID:CLIENT_SECRET`, the resulting string should be `Q0xJRU5UX0lEOkNMSUVOVF9TRUNSRVQ=`.
 
     * You will need to send the following HTTP headers (replace anything between `<>`, including `<>`):
-        * `Authorization: Basic <URL safe Base64 encoded credentials>`
+        * `Authorization: Basic <Base64 encoded credentials>`
         * `Content-Type: application/x-www-form-urlencoded`
         * `Host: login.eveonline.com`
 


### PR DESCRIPTION
I did some testing with the 4 dev applications I have, and confirmed that none of them resulted in `/` or `+` being included in the resulting base64 string. This is probably due to the limited character set of the client id/secret. If someone's credentials _does_ include those, we should determine if it actually matters if its URL safe or not. As [Basic Auth RFC](https://datatracker.ietf.org/doc/html/rfc7617#section-2) points to the non URL safe [Base64 RFC](https://datatracker.ietf.org/doc/html/rfc4648#section-4). So I'm skeptical if URL safe was the right thing to suggest in the first place.

I also clarified, and added an example, that padding on the base64 string is required. The example could be used to give a point of reference for someone to validate their implementation against.

Somewhat alievates https://github.com/ccpgames/sso-issues/issues/75, but it should still ultimately `403` if invalid credentials are provided.