### PR TITLE
Add new audience claim to JWT code example and docs

### DIFF
--- a/docs/sso/validating_eve_jwt.md
+++ b/docs/sso/validating_eve_jwt.md
@@ -16,24 +16,36 @@ Listed below are the most important things to validate when using the JWT tokens
   "kid": "JWT-Signature-Key",
   "sub": "CHARACTER:EVE:123123",
   "azp": "my3rdpartyclientid",
+  "tenant": "tranquility",
+  "tier": "live",
+  "region": "world",
+  "aud": "EVE Online",
   "name": "Some Bloke",
   "owner": "8PmzCeTKb4VFUDrHLc/AeZXDSWM=",
-  "exp": 1534412504,
+  "exp": 1648563218,
+  "iat": 1648562018,
   "iss": "login.eveonline.com"
 }
 ```
 
 ## Validating an EVE SSO JWT token
-You will need to ensure three things when validating a JWT token from the EVE SSO:
+
+You will need to ensure four things when validating a JWT token from the EVE SSO:
 
 1. ### Validate the JWT signature
+
     The [SSO metadata endpoint](https://login.eveonline.com/.well-known/oauth-authorization-server) contains a description of the supported operations for the SSO. That endpoint lists the supported endpoints as well as provides a link to the SSO JWT key set which is currently located at <https://login.eveonline.com/oauth/jwks>. You will need to load that key set using whatever JWT library available. Currently the SSO uses the RS-256 signature method, but will also support ES-256 in the near future.
 
 1. ### Validate the issuer
-    The issuer will either be the host name or the URI of the SSO instance you are using (e.g. login.eveonline.com or https://login.eveonline.com). Your application should handle looking for both the host name and the URI in the `iss` claim and should reject any JWT tokens where `iss` does not equal the host name or URI of EVE's SSO.
+
+    The issuer will either be the host name or the URI of the SSO instance you are using (e.g. `"login.eveonline.com"` or `"https://login.eveonline.com"`). Your application should handle looking for both the host name and the URI in the `iss` claim and should reject any JWT tokens where `iss` does not equal the host name or URI of EVE's SSO.
 
 1. ### Validate the expiry date
+
     The `exp` claim contains the expiry date of the token as a UNIX timestamp. You can use that to know when to refresh the token and to make sure that the token is valid.
 
+1. ### Validate the audience claim
+
+    The `aud` claim contains the audience and must match the string value: `"EVE Online"`
 
 You can look [here](https://github.com/esi/esi-docs/blob/master/examples/python/sso/validate_jwt.py) for a code example in Python showing you how to validate a JWT token.

--- a/examples/python/sso/validate_jwt.py
+++ b/examples/python/sso/validate_jwt.py
@@ -1,4 +1,4 @@
-"""Validates a given JWT token originating from the EVE SSO.
+"""Validates a given JWT access token originating from the EVE SSO.
 
 Prerequisites:
     * Have a Python 3 environment available to you (possibly by using a
@@ -9,7 +9,7 @@ This can be run by doing
 
 >>> python validate_jwt.py
 
-and passing in a JWT token that you have retrieved from the EVE SSO.
+and passing in a JWT access token that you have retrieved from the EVE SSO.
 """
 import sys
 
@@ -17,59 +17,73 @@ import requests
 from jose import jwt
 from jose.exceptions import ExpiredSignatureError, JWTError
 
+SSO_META_DATA_URL = "https://login.eveonline.com/.well-known/oauth-authorization-server"
+JWK_ALGORITHM = "RS256"
+JWK_ISSUERS = ("login.eveonline.com", "https://login.eveonline.com")
+JWK_AUDIENCE = "EVE Online"
 
-def validate_eve_jwt(jwt_token: str) -> dict:
-    """Validate a JWT token retrieved from the EVE SSO.
+
+def validate_eve_jwt(token: str) -> dict:
+    """Validate a JWT access token retrieved from the EVE SSO.
 
     Args:
-        jwt_token: A JWT token originating from the EVE SSO
+        token: A JWT access token originating from the EVE SSO
     Returns:
-        The contents of the validated JWT token if there are no validation errors
+        The contents of the validated JWT access token if there are no errors
     """
+    # fetch JWKs URL from meta data endpoint
+    res = requests.get(SSO_META_DATA_URL)
+    res.raise_for_status()
+    data = res.json()
+    try:
+        jwks_uri = data["jwks_uri"]
+    except KeyError:
+        raise RuntimeError(
+            f"Invalid data received from the SSO meta data endpoint: {data}"
+        ) from None
+
     # fetch JWKs from endpoint
-    res = requests.get("https://login.eveonline.com/oauth/jwks")
+    res = requests.get(jwks_uri)
     res.raise_for_status()
     data = res.json()
     try:
         jwk_sets = data["keys"]
-    except KeyError as e:
-        print(
-            "Something went wrong when retrieving the JWK set. "
-            f"The returned payload did not have the expected key {e}.\n"
-            f"Payload returned from the SSO looks like: {data}"
-        )
-        sys.exit(1)
+    except KeyError:
+        raise RuntimeError(
+            f"Invalid data received from the the jwks endpoint: {data}"
+        ) from None
 
-    # pick the JWK with the RS256 alogorithm
-    jwk_set = [item for item in jwk_sets if item["alg"] == "RS256"].pop()
+    # pick the JWK with the requested alogorithm
+    jwk_set = [item for item in jwk_sets if item["alg"] == JWK_ALGORITHM].pop()
 
     # try to decode the token and validate it against expected values
-    # will raise exceptions if decoding fails or expected values do not match
-    jwt_token = jwt.decode(
-        jwt_token,
-        jwk_set,
+    # will raise JWT exceptions if decoding fails or expected values do not match
+    contents = jwt.decode(
+        token=token,
+        key=jwk_set,
         algorithms=jwk_set["alg"],
-        issuer=("login.eveonline.com", "https://login.eveonline.com"),
-        audience="EVE Online",
+        issuer=JWK_ISSUERS,
+        audience=JWK_AUDIENCE,
     )
-    return jwt_token
+    return contents
 
 
 def main():
-    """Manually input a JWT token to be validated."""
-
     token = input("Enter an access token to validate: ")
 
     try:
-        validated_jwt = validate_eve_jwt(token)
+        token_contents = validate_eve_jwt(token)
     except ExpiredSignatureError:
         print("The JWT token has expired")
         sys.exit(1)
     except JWTError as e:
         print(f"The JWT token was invalid: {e}")
         sys.exit(1)
-
-    print(f"\nThe contents of the access token are: {validated_jwt}")
+    except RuntimeError as e:
+        print(str(e))
+        sys.exit(1)
+    else:
+        print(f"\nThe contents of the access token are:\n{token_contents}")
 
 
 if __name__ == "__main__":

--- a/examples/python/sso/validate_jwt.py
+++ b/examples/python/sso/validate_jwt.py
@@ -15,70 +15,61 @@ import sys
 
 import requests
 from jose import jwt
-from jose.exceptions import ExpiredSignatureError, JWTError, JWTClaimsError
+from jose.exceptions import ExpiredSignatureError, JWTError
 
 
-def validate_eve_jwt(jwt_token):
+def validate_eve_jwt(jwt_token: str) -> dict:
     """Validate a JWT token retrieved from the EVE SSO.
 
     Args:
         jwt_token: A JWT token originating from the EVE SSO
-    Returns
-        dict: The contents of the validated JWT token if there are no
-              validation errors
+    Returns:
+        The contents of the validated JWT token if there are no validation errors
     """
-
-    jwk_set_url = "https://login.eveonline.com/oauth/jwks"
-
-    res = requests.get(jwk_set_url)
+    # fetch JWKs from endpoint
+    res = requests.get("https://login.eveonline.com/oauth/jwks")
     res.raise_for_status()
-
     data = res.json()
-
     try:
         jwk_sets = data["keys"]
     except KeyError as e:
-        print("Something went wrong when retrieving the JWK set. The returned "
-              "payload did not have the expected key {}. \nPayload returned "
-              "from the SSO looks like: {}".format(e, data))
-        sys.exit(1)
-
-    jwk_set = next((item for item in jwk_sets if item["alg"] == "RS256"))
-
-    try:
-        return jwt.decode(
-            jwt_token,
-            jwk_set,
-            algorithms=jwk_set["alg"],
-            issuer="login.eveonline.com"
+        print(
+            "Something went wrong when retrieving the JWK set. "
+            f"The returned payload did not have the expected key {e}.\n"
+            f"Payload returned from the SSO looks like: {data}"
         )
-    except ExpiredSignatureError:
-        print("The JWT token has expired: {}")
         sys.exit(1)
-    except JWTError as e:
-        print("The JWT signature was invalid: {}").format(str(e))
-        sys.exit(1)
-    except JWTClaimsError as e:
-        try:
-            return jwt.decode(
-                        jwt_token,
-                        jwk_set,
-                        algorithms=jwk_set["alg"],
-                        issuer="https://login.eveonline.com"
-                    )
-        except JWTClaimsError as e:
-            print("The issuer claim was not from login.eveonline.com or "
-                  "https://login.eveonline.com: {}".format(str(e)))
-            sys.exit(1)
+
+    # pick the JWK with the RS256 alogorithm
+    jwk_set = [item for item in jwk_sets if item["alg"] == "RS256"].pop()
+
+    # try to decode the token and validate it against expected values
+    # will raise exceptions if decoding fails or expected values do not match
+    jwt_token = jwt.decode(
+        jwt_token,
+        jwk_set,
+        algorithms=jwk_set["alg"],
+        issuer=("login.eveonline.com", "https://login.eveonline.com"),
+        audience="EVE Online",
+    )
+    return jwt_token
 
 
 def main():
     """Manually input a JWT token to be validated."""
 
     token = input("Enter an access token to validate: ")
-    validated_jwt = validate_eve_jwt(token)
 
-    print("\nThe contents of the access token are: {}".format(validated_jwt))
+    try:
+        validated_jwt = validate_eve_jwt(token)
+    except ExpiredSignatureError:
+        print("The JWT token has expired")
+        sys.exit(1)
+    except JWTError as e:
+        print(f"The JWT token was invalid: {e}")
+        sys.exit(1)
+
+    print(f"\nThe contents of the access token are: {validated_jwt}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change updates the code example and documentation on how to work with JWTs for the newly added audience claim.

## Code example for validating JWTs
- Fixes the code example by adding the new audience claim
- Refactors the code example to make it easier to read and understand

## Documentation
- Add new requirement for checking audience claim 
- Add info about new private names in JWT example
- Minor cleanup from markdown linter
