### PR TITLE
Assets location_id can not be a character_id

### DIFF
--- a/docs/asset_location_id.md
+++ b/docs/asset_location_id.md
@@ -16,7 +16,6 @@ Resolvable via:
   - The [ESI structure endpoint](https://esi.evetech.net/ui/#/Universe/get_universe_structures_structure_id) (if you have docking rights)
   - The [ESI bookmark endpoint](https://esi.evetech.net/ui/#/Bookmarks/get_characters_character_id_bookmarks) (all structures you have bookmarked, resolve structures regardless of docking rights)
 - **Customs Office ID** (Those are not resolvable, see [ESI feature request](https://github.com/esi/esi-issues/issues/685), Note: they share ID range with Item IDs and Structure IDs)
-- **Character ID** (when `location_flag` is `wardrobe`)
 - **Corporation Office ID** (Not resolvable, when `location_flag` is `OfficeFolder`, link between Hangars/Divisions (`location_flag`: `CorpSAGx`) and Structure/Station ID's.)
 
 ### Asset Tree example
@@ -27,6 +26,7 @@ Resolvable via:
 - item_id: 1000000000003, location_id: 1000000000001
 - item_id: 1000000000004, location_id: 1000000000003
 - item_id: 1000000000005, location_id: 1000000000003
+
 #### Tree
 - item_id: 1000000000001, location_id: 60002959
   - item_id: 1000000000003, location_id: 1000000000001
@@ -39,4 +39,5 @@ Resolvable via:
 - Returned destroyed assets ([ESI Issue](https://github.com/esi/esi-issues/issues/698))
 - Returned 9e18 locations ([ESI Issue](https://github.com/esi/esi-issues/issues/684))
 - Returned trained skills and active boosters ([ESI Issue](https://github.com/esi/esi-issues/issues/911))
-- Returned  PI structures [ESI Issue](https://github.com/esi/esi-issues/issues/943)
+- Returned PI structures ([ESI Issue](https://github.com/esi/esi-issues/issues/943))
+- Returned Character IDs ([ESI Issue](https://github.com/esi/esi-issues/issues/911))


### PR DESCRIPTION
Assets location_id can not no longer be a CharacterIDs.
That bug was fixed long ago:
https://github.com/esi/esi-issues/issues/911 🚗