### PR TITLE
Fix python prompt style terminal prompt

### DIFF
--- a/examples/python/sso/esi_oauth_native.py
+++ b/examples/python/sso/esi_oauth_native.py
@@ -15,7 +15,7 @@ Prerequisites:
 To run this example, make sure you have completed the prerequisites and then
 run the following command from this directory as the root:
 
->>> python esi_oauth_native.py
+> python esi_oauth_native.py
 
 then follow the prompts.
 """

--- a/examples/python/sso/esi_oauth_web.py
+++ b/examples/python/sso/esi_oauth_web.py
@@ -15,7 +15,7 @@ Prerequisites:
 To run this example, make sure you have completed the prerequisites and then
 run the following command from this directory as the root:
 
->>> python esi_oauth_web.py
+> python esi_oauth_web.py
 
 then follow the prompts.
 """

--- a/examples/python/sso/revoke_refresh_token.py
+++ b/examples/python/sso/revoke_refresh_token.py
@@ -7,7 +7,7 @@ Prerequisites:
 
 This can be run by doing
 
->>> python revoke_refresh_token.py
+> python revoke_refresh_token.py
 
 and entering the data prompted for.
 """

--- a/examples/python/sso/validate_jwt.py
+++ b/examples/python/sso/validate_jwt.py
@@ -7,7 +7,7 @@ Prerequisites:
 
 This can be run by doing
 
->>> python validate_jwt.py
+> python validate_jwt.py
 
 and passing in a JWT access token that you have retrieved from the EVE SSO.
 """


### PR DESCRIPTION
Change the prompts in the examples descriptions from '>>>' to '>' i.e. from python style to cmd/ps style.

'>>> python something' doesn't make a lot of sense as '>>>' is already a running python interpreter.

Also pycharm interprets the '>>>' inside text blocks and this prevents the code from running inside pycharm.