### PR TITLE
Fix: Load mermaid.min.js from cdnjs instead of the default unpkg

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ extra_css:
 extra_javascript:
   - assets/javascript/theme.js
   - assets/javascript/mathjax.js
+  - https://cdnjs.cloudflare.com/ajax/libs/mermaid/11.0.0/mermaid.min.js
   - https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js
 
 extra:


### PR DESCRIPTION
UnPkg seems to have been having some problems recently, with people reporting very slow load times. This forces mermaid.js to load from cdnjs to avoid this.