### PR TITLE
Fix: make the home logo URL relative

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,7 @@ extra_javascript:
   - https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js
 
 extra:
-  homepage: !ENV [SITE_HOME, 'https://developers.eveonline.com/']
+  homepage: /
   analytics:
     provider: custom
     property: !ENV [GTM_ID, 'GTM-XXXXXXX']

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -13,8 +13,6 @@ set class = class ~ " md-header--shadow md-header--lifted" %} {% elif
       ".icons/" ~ icon ~ ".svg" %}
     </label>
 
-
-
     <!-- Link to home -->
     <a
       href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"


### PR DESCRIPTION
This ensures that open-in-new-tab doesn't think it's an external link