### PR TITLE
Add deprecation notice & last-update date to Image Export Collection docs

### DIFF
--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -20,9 +20,9 @@ The `Full SDE` package contains the same files as the `FSD`, `BSD`, and `Univers
 
 Some community members have created tools to help manage the SDE, or to provide them in different formats
 
-# Image Export Collection (IEC)
+# (Deprecated) Image Export Collection (IEC)
 
-Export for `Uprising (V21.03)`
+Export for `Uprising (V21.03 - March 14th 2023)`
 
 - [Icons](https://web.ccpgamescdn.com/aws/developers/Uprising_V21.03_Icons.zip)
 - [Renders](https://web.ccpgamescdn.com/aws/developers/Uprising_V21.03_Renders.zip)


### PR DESCRIPTION
IEC's been deprecated since 2019 - https://developers.eveonline.com/blog/upcoming-changes-to-the-image-export-collection
* Deprecation notice in IEC heading on Documentation -> Resources page
* Include date of game update to indicate latest IEC version (2023-03-14) is quite outdated