### PR TITLE
Add link to the EVE Developer Documentation website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Repository for the [EVE Developer Documentation](https://developers.eveonline.com/docs/) website.
+
 # Local environment
 
 This project works best when you have a local environment set up, preferably via WSL2.


### PR DESCRIPTION
The Readme didn't actually mention the website it's for or where to find the live version.