### PR TITLE
Add: Glossary file

### DIFF
--- a/docs/guides/glossary.md
+++ b/docs/guides/glossary.md
@@ -1,0 +1,78 @@
+# Glossary
+
+This document is a list of common or unusual terms used in EVE 3rd party development and their meanings.
+
+### APIs & Data sources
+
+* [*ESI*](../services/esi/overview.md) - "EVE Swagger Interface"  
+  Current 3rd party development API  
+* [*SDE*](../services/sde/index.md) - "Static Data Export"  
+  Export of static game data (only changing with game updates)  
+* *CREST* - "Carbon RESTful API"  
+  Previous generation 3rd party dev API (Defunct since 2018)  
+* *XML API*  
+  Previous generation 3rd party dev API (Defunct since 2018)  
+* *IGB* - "In-Game Browser"  
+  In-game browser & related APIs (Defunct since 2016)  
+* *Static Data Dump*  
+  Prior version of *SDE*  
+
+### Data Formats
+
+* [*EFT*](./fitting.md#eft) - "EVE Fitting Tool"  
+  Human-Readable format for ship fittings from the now-defunct third party program of the same name  
+* [*Ship DNA*](./fitting.md#dna)  
+  Compact data format for ship fittings, used in now-defunct APIs & some third-party tools  
+* [*XML Fitting*](./fitting.md#xml)  
+  Older XML-based fitting format  
+
+### Data Types
+
+* *Type*  
+  Game item. Types describe most "things" in the game; 'Inventory'/cargo items, ships, objects in space  
+  Found in the SDE in `fsd/types.yaml`, through ESI under `/universe/types/`  
+* *Item*  
+  Individual instances of a type; e.g. Type 648 ("Badger") describes all Badger ships, any individual assembled ship has a unique itemID   
+  An "object" as opposed to a "class" in programming terms  
+* *Group*  
+  Collection of related *Types*  
+  Not to be confused with *MetaGroup* or *MarketGroup*  
+  Found in the SDE in `fsd/groups.yaml`, through ESI under `/universe/groups/`  
+* *Category*  
+  Collection of related *Groups*  
+  Usually differentiates the "kind" of object; E.g. "Ship" and "Module" are different Categories  
+  Found in the SDE in `fsd/categories.yaml`, through ESI under `/universe/categories/`  
+* *MetaGroup*  
+  Tech-tier such as T1/T2/T3/Faction  
+  Not to be confused with regular item *Group* or *MarketGroup*  
+  Found in the SDE in `fsd/metaGroups.yaml`, not available through ESI  
+* *MarketGroup*  
+  A single tab (or tab group) in the market  
+  Not to be confused with regular item *Group* or *MetaGroup*  
+  Found in the SDE in `fsd/marketGroups.yaml`, through ESI under `/markets/groups/`  
+* *Icon*  
+  Icon images, such as inventory icons, UI icons, overview icons, etc.  
+  Found in the SDE in `fsd/iconIDs.yaml`, not available through ESI  
+* *Graphic*  
+  Data about 3D models; Model geometry, textures, icons/renders of those models  
+  Found in the SDE in `fsd/graphicIDs.yaml`, through ESI under `/universe/graphics/`  
+* *Attribute*  
+  (Additional) properties of a *Type*, such as HP, maximum velocity, and other item stats  
+  Found in the SDE in `fsd/dogmaAttributes.yaml`, through ESI under `/dogma/attributes/`  
+* *Effect*  
+  Game logic element. Describes interactions between attributes  
+  Some properties are also stored as effects rather than attributes (E.g. which slot a module uses)  
+  Found in the SDE in `fsd/dogmaEffects.yaml`, through ESI under `/dogma/effects/`  
+
+### Technical & other terms
+
+* *BSD* - "Branched Static Data"  
+  Old authoring format for game data, not all data has been ported over to the new *FSD* "File Static Data"  
+  No meaningful difference to *FSD* for users  
+* *FSD* - "File Static Data"  
+  New authoring format for game data, not all data has been ported over  
+  No meaningful difference to *BSD* for users  
+* *Dogma*  
+  Collective term for *Attributes*, *Effects* and the game logic around them  
+* *Monolith*  
+  The EVE Online servers (In particular, the database)  


### PR DESCRIPTION
There's been a few cases of people wanting to document small bits of jargon, but there not being a good place in the documentation to do so. This PR is a first attempt at a dedicated glossary page.

Definitions & formatting need another set of eyes on them. Other considerations:
* Accessibility -> Avoiding overly technical and "accurate" definitions that rely on jargon. Maybe aim for "novice programmer" level?
* Should this include the 'data types'? Right now individual ESI endpoints & SDE data doesn't have their own docs, leaving these terms without documentation. Maybe leave them in the glossary for now, and remove them if/when dedicated pages happen?
* Ordering/layout? Currently grouped, groups in a vague "most to least common" order