### PR TITLE
Add missing header and sidebar items

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -12,5 +12,5 @@
 * Guides and Examples
     * guides/*.md
     * guides/*/index.md
-* [Community](community/index.md)
+* [Community Showcase](community/index.md)
     * community/*/index.md

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -30,10 +30,16 @@ set class = class ~ " md-header--shadow md-header--lifted" %} {% elif
         <a href="/docs/">Documentation</a>
       </div>
       <div class="esi-nav-header-item">
+        <a href="/api-explorer">API Explorer</a>
+      </div>
+      <div class="esi-nav-header-item">
         <a href="/applications">Applications</a>
       </div>
       <div class="esi-nav-header-item">
         <a href="/authorized-apps">Authorized Apps</a>
+      </div>
+      <div class="esi-nav-header-item">
+        <a href="/docs/community/">Community Showcase</a>
       </div>
     </nav>
 

--- a/overrides/partials/sidebar-nav.html
+++ b/overrides/partials/sidebar-nav.html
@@ -120,10 +120,16 @@
       <a href="/docs/">Documentation</a>
     </li>
     <li class="esi-sidebar-nav-item">
+      <a href="/api-explorer">API Explorer</a>
+    </li>
+    <li class="esi-sidebar-nav-item">
       <a href="/applications">Applications</a>
     </li>
     <li class="esi-sidebar-nav-item">
       <a href="/authorized-apps">Authorized Apps</a>
+    </li>
+    <li class="esi-sidebar-nav-item">
+      <a href="/docs/community/">Community Showcase</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
Added header and sidebar menu items that appear on the other pages but not on the documentation pages, so they were appearing and disappearing when navigating the developer site.

There is still the difference that "Applications" and "Authorized Apps" were collapsed into a single item with a submenu on the other pages, but they remain separate here. Should probably be unified too.