### PR TITLE
add goesi-openapi to community pages

### DIFF
--- a/docs/community/eve-esi-golang/index.md
+++ b/docs/community/eve-esi-golang/index.md
@@ -1,0 +1,23 @@
+---
+search:
+  exclude: true
+
+title: EVE API for Golang
+type: resource
+description: Go client library for EVE Online's ESI API with OAuth2 authentication, PKCE support, and automatic spec updates.
+maintainer:
+  name: fnt-eve
+  github: fnt-eve
+---
+
+# EVE API for Golang
+
+A Go client library for the EVE Online ESI API, generated from the official OpenAPI specification.
+
+This library is a spiritual successor to the original [goesi](https://github.com/antihax/goesi) package, updated to support CCP's OpenAPI 3.x+ specification. Generated using [Openapi Generator](https://github.com/openapitools/openapi-generator).
+
+<div class="grid cards" markdown>
+
+- [:octicons-mark-github-16: **GitHub**](https://github.com/fnt-eve/goesi-openapi){ .esi-card-link }
+
+</div>


### PR DESCRIPTION
Adding my library [goesi-openapi](https://github.com/fnt-eve/goesi-openapi) to community pages.