### PR TITLE
feat: Add EveAuth for Python to community showcases

### DIFF
--- a/docs/community/eve-auth-for-python/index.md
+++ b/docs/community/eve-auth-for-python/index.md
@@ -1,0 +1,31 @@
+---
+search:
+  exclude: true
+
+title: EVE Auth for Python
+type: resource
+description: A Python library for authorizing desktop applications with the EVE Online SSO service.
+maintainer:
+  name: Erik Kalkoken
+  github: ErikKalkoken
+---
+
+# EVE Auth for Python
+
+A Python library for authorizing desktop applications with the EVE Online SSO service.
+
+[![release](https://img.shields.io/pypi/v/python-eveauth?label=release)](https://pypi.org/project/python-eveauth/)
+[![python](https://img.shields.io/pypi/pyversions/python-eveauth)](https://pypi.org/project/python-eveauth/)
+[![license](https://img.shields.io/badge/license-MIT-green)](https://gitlab.com/ErikKalkoken/python-eveauth/-/blob/master/LICENSE)
+
+<div class="grid cards" markdown>
+
+- [:octicons-browser-16: **Website**](https://erikkalkoken.github.io/python-eveauth){ .esi-card-link }
+- [:octicons-mark-github-16: **GitHub**](https://github.com/ErikKalkoken/python-eveauth){ .esi-card-link }
+
+</div>
+
+**python-eveauth** is a library for authorizing Python scripts on desktops with the EVE online SSO.
+It enables a Python script (e.g. CLI tools, GUI apps or Jupiter notebooks) to obtain SSO tokens that grant authenticated access to the EVE Online API (ESI).
+
+For more information please visit the [Github repository](https://github.com/ErikKalkoken/python-eveauth).


### PR DESCRIPTION
I would like to add the new library "EveAuth for Python" to the community showcases.