### PR TITLE
Add EVE Wormhole Atlas to community services

### DIFF
--- a/docs/community/eve-wormhole-atlas/index.md
+++ b/docs/community/eve-wormhole-atlas/index.md
@@ -1,0 +1,36 @@
+---
+search:
+  exclude: true
+
+title: EVE Wormhole Atlas
+type: service
+description: A practical wormhole expedition atlas with doctrine fits, multibuy lists, logistics notes, and operating playbooks for small groups.
+maintainer:
+  name: MrBoostie
+  github: MrBoostie
+---
+
+# EVE Wormhole Atlas
+
+EVE Wormhole Atlas is a public guide site for small-group wormhole expeditions, day-tripping, scouting, and short-stay logistics. It focuses on practical operating doctrine: what to stage, what to fly, what to buy, and what mechanics new wormhole pilots need to respect before J-space teaches the lesson with teeth.
+
+<div class="grid cards" markdown>
+
+- [:octicons-browser-16: **Website**](https://mrboostie.github.io/eve-wormhole-atlas/){ .esi-card-link }
+- [:simple-github: **GitHub**](https://github.com/MrBoostie/eve-wormhole-atlas){ .esi-card-link }
+- [:octicons-issue-opened-16: **Feedback**](https://github.com/MrBoostie/eve-wormhole-atlas/issues){ .esi-card-link }
+
+</div>
+
+## Features
+
+- Copy-paste EVE fitting blocks for baseline wormhole hangars.
+- Multibuy lists for staging logistics and replacement ships.
+- Viator-first logistics planning for blockade-runner hauling.
+- Astero-focused scouting and hunting guidance.
+- Wormhole mechanics notes covering polarization, K162 behavior, mass and life stages, no asset safety, and bookmarking the actual wormhole object.
+- Operational guidance for Thera, Turnur, short-stay staging, scouting loops, and Sleeper relic/data site risk.
+
+## Feedback
+
+The project is actively seeking corrections and field-tested suggestions from wormhole pilots, especially around fits, multibuy quantities, beginner explanations, and practical small-group operating doctrine.


### PR DESCRIPTION
Adds EVE Wormhole Atlas, a public wormhole expedition guide site with doctrine fits, multibuy lists, logistics notes, and small-group operating playbooks.\n\nThe site is seeking feedback from EVE wormhole players and third-party community maintainers.