### PR TITLE
Add EVE AI Agent to Community Showcase

### DIFF
--- a/docs/community/eve-ai-agent/index.md
+++ b/docs/community/eve-ai-agent/index.md
@@ -1,0 +1,33 @@
+---
+search:
+  exclude: true
+
+title: EVE AI Agent
+type: service
+description: A self-hosted chat-first AI assistant for EVE Online with Telegram and Discord bots, EVE SSO, live ESI data, local SDE search, route planning, and killboard intelligence.
+maintainer:
+  name: garshany
+  github: garshany
+---
+
+# EVE AI Agent
+
+EVE AI Agent is a self-hosted chat-first assistant for EVE Online. Run it with Telegram or Discord, or use its terminal CLI. It uses the official EVE SSO and ESI APIs for player-authorized character data, a local SDE SQLite database for static data, and public EVE community data sources for route and combat intelligence.
+
+<div class="grid cards" markdown>
+
+- [:octicons-mark-github-16: __GitHub__](https://github.com/garshany/eveai){ .esi-card-link }
+
+</div>
+
+## Features
+
+- Natural-language EVE assistance in Telegram private chats, Discord DMs, or a terminal CLI.
+- EVE SSO character linking with encrypted local token storage and scope-aware access to private ESI data.
+- Local SDE lookup for systems, items, dogma, blueprints, and routes; live ESI for authorized character, corporation, market, assets, skills, industry, mail, and location data.
+- Route planning with danger analysis, killmail context, gate-camp signals, and Thera or Turnur shortcuts.
+- D-scan, local and fleet analysis, zKillboard and EVE-KILL intelligence, EVE-Scout data, and opt-in chat notifications.
+
+## Self-hosting
+
+The project is available under the MIT license. See its GitHub README for setup, EVE Developer application configuration, and deployment guidance.


### PR DESCRIPTION
## Summary

Adds EVE AI Agent to the Community Showcase as a self-hosted service for end users. The project provides Telegram and Discord bots plus a terminal CLI, using EVE SSO/ESI, local SDE data, route planning, and EVE combat-intelligence sources.

## Eligibility

- directly related to EVE Online and documents the EVE Developer License Agreement boundary;
- public source repository: https://github.com/garshany/eveai;
- production-ready immutable v3.0.0 self-hosting release with reproducible setup and public CI;
- GitHub records the repository's initial public event on 2026-03-24 and public `master` CI on 2026-03-25, so it has been public for more than three months;
- actively maintained, with the current release and CI verified on 2026-07-13.

## Validation

- exact diff: one new 33-line Community Showcase page;
- based on current `esi/esi-docs:main`;
- `make test` — strict MkDocs build passed;
- independent read-only review passed.
