### PR TITLE
Add ISK.GG to Community Showcase

### DIFF
--- a/docs/community/isk-gg/index.md
+++ b/docs/community/isk-gg/index.md
@@ -1,0 +1,36 @@
+---
+search:
+  exclude: true
+
+title: ISK.GG
+type: service
+description: Browser-based market explorer for EVE Online orders and regional price history. Includes region, system, and station/structure scopes, order books, depth charts, advanced filters, saved views, Quickbar import, CSV export, and mobile/tablet support.
+maintainer:
+  name: ImperfectX
+  github: imperfectxx
+---
+
+# ISK.GG
+
+ISK.GG is a free browser-based market explorer for EVE Online. It provides live buy and sell orders and regional price history across regions, systems, stations, and supported player structures without requiring an account.
+
+<div class="grid cards" markdown>
+
+- [:octicons-browser-16: __Website__](https://isk.gg){ .esi-card-link }
+- [:simple-discord: __Discord__](https://discord.gg/9cb3UdBtzy){ .esi-card-link }
+
+</div>
+
+## Features
+
+- Buy and sell orders refreshed approximately every five minutes
+- Regional market history updated daily
+- Cross-region price comparison charts
+- Order books, market depth, and price charts
+- Scopes for regions, systems, stations, and supported player structures
+- Advanced filters, sorting, and configurable tables
+- Saved items, nested folders, and saved views
+- In-game Market Quickbar import and CSV export
+- Full desktop, tablet, and mobile support
+
+Market inputs come from ESI. ISK.GG is free and does not require an account.


### PR DESCRIPTION
## Summary

Adds ISK.GG, a free browser-based market explorer for EVE Online orders and regional price history, to the Community Showcase.

## Eligibility

- Public and production-ready at https://isk.gg
- Public since at least April 3, 2026: [beta launch post](https://www.reddit.com/r/Eve/comments/1sbj70b/i_built_a_free_market_browser_for_eve/)
- Actively maintained, with the latest major release announced in July 2026: [release post](https://www.reddit.com/r/Eve/comments/1v1re2t/iskgg_market_browser_is_out_of_beta/)
- Uses ESI for market data and follows the EVE Online Developer License Agreement

I can provide anonymized usage analytics if helpful during review.